### PR TITLE
Remove wrong use for BounceStatus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["php", "bounce", "email", "mail"],
     "homepage": "https://github.com/rambomst/PHP-Bounce-Handler/",
     "license": "BSD",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "authors": [
         {
             "name": "Kristian Løining",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["php", "bounce", "email", "mail"],
     "homepage": "https://github.com/rambomst/PHP-Bounce-Handler/",
     "license": "BSD",
-    "version": "1.2",
+    "version": "1.2.1",
     "authors": [
         {
             "name": "Kristian Løining",

--- a/composer.json
+++ b/composer.json
@@ -8,17 +8,13 @@
     "version": "1.2",
     "authors": [
         {
-            "name": "Patrick O'Connell",
-            "role": "Developer"
-        },
-        {
             "name": "Kristian Løining",
             "role": "Developer"
         }
     ],
     "autoload": {
         "psr-4": {
-            "rambomst\\PHPBounceHandler\\": "src/"
+            "kloining\\PHPBounceHandler\\": "src/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rambomst/php-bounce-handler",
+    "name": "kloining/php-bounce-handler",
     "type": "library",
     "description": "Parses email bounce notifications and turns them into associative arrays and returns header information with bounce statuses",
     "keywords": ["php", "bounce", "email", "mail"],

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
         {
             "name": "Patrick O'Connell",
             "role": "Developer"
+        },
+        {
+            "name": "Kristian Løining",
+            "role": "Developer"
         }
     ],
     "autoload": {

--- a/src/BounceHandler.php
+++ b/src/BounceHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rambomst\PHPBounceHandler;
+namespace kloining\PHPBounceHandler;
 
 class BounceHandler {
 

--- a/src/BounceHandler.php
+++ b/src/BounceHandler.php
@@ -2,8 +2,6 @@
 
 namespace rambomst\PHPBounceHandler;
 
-use BounceStatus;
-
 class BounceHandler {
 
     // Properties

--- a/src/BounceStatus.php
+++ b/src/BounceStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rambomst\PHPBounceHandler;
+namespace kloining\PHPBounceHandler;
 
 class BounceStatus {
 


### PR DESCRIPTION
As both BounceHandler and BounceStatus are in the same namespace, autoloader breaks because of a wrong BounceStatus use case.